### PR TITLE
Update lodash dep because of vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "should": "^5.2.0"
   },
   "dependencies": {
-    "lodash": "^3.7.0"
+    "lodash": "^4.17.15"
   },
   "keywords": [
     "bdd",


### PR DESCRIPTION
Given the context respect is used it, very unlikely to be a real issue but this dep update will fix warnings for `npm audit`.

I was not able to get the repo tests running, so hopefully this doesn't break anything.